### PR TITLE
Correctly inherit error object

### DIFF
--- a/lib/DAV/exceptions.js
+++ b/lib/DAV/exceptions.js
@@ -79,7 +79,8 @@ exports.jsDAV_Exception = function(msg, extra) {
         }
     };
 };
-exports.jsDAV_Exception.prototype = new Error();
+require('util').inherits(exports.jsDAV_Exception, Error);
+
 
 /**
  * BadRequest


### PR DESCRIPTION
requiring the exceptions module incorrectly triggers an "Error".

node.js:201
throw e; // process.nextTick error, or 'error' event on first tick
^
Error
at Object. (/home/ubuntu/initme_agent/jsDAV/lib/DAV/exceptions.js:82:37)
at Module._compile (module.js:432:26)
at Object..js (module.js:450:10)
at Module.load (module.js:351:31)
at Function._load (module.js:310:12)
at Module.require (module.js:357:17)
at require (module.js:368:17)
at Object. (/home/ubuntu/initme_agent/jsDAV/lib/DAV/server.js:14:14)
at Module._compile (module.js:432:26)
at Object..js (module.js:450:10)
