### PR TITLE
Fix FTP Crash: Checkes if `res` is set at all 

### DIFF
--- a/lib/DAV/tree/ftp.js
+++ b/lib/DAV/tree/ftp.js
@@ -83,7 +83,7 @@ exports.jsDAV_Tree_Ftp = jsDAV_Tree_Ftp;
         var baseName = Path.basename(path).replace("/", "");
         ftp.ls(Path.dirname(path), function(err, res) {
             if (err) {
-                if (res.code === 530) // Not logged in
+                if (res && res.code === 530) // Not logged in
                     ftp.auth(self.options.user, self.options.pass, function(err, res) {
                         if (!err)
                             self.getNodeForPath(path, next);


### PR DESCRIPTION
(not always the case in an error condition).

Should fix: https://github.com/ajaxorg/cloud9infra/issues/373

@mikedeboer 
