### PR TITLE
Fix an issue that 'addEventListener' always enables timeout

### DIFF
--- a/lib/DAV/util.js
+++ b/lib/DAV/util.js
@@ -1008,7 +1008,7 @@ var _slice = Array.prototype.slice;
     this.addEventListener = function(eventName, listener, prio, timeout) {
         persistRegistry.call(this);
 
-        listener.$usetimeout = timeout === false
+        listener.$usetimeout = timeout == null
             ? 0
             : (typeof timeout == "number")
                 ? timeout


### PR DESCRIPTION
This issue cause 'addEventListener' ALWAYS enable a 10 seconds timeout mechanism. May cause strange behaviors when server try to do a gracefully shutdown.
