### PR TITLE
Fix handling of if-unmodified-since headers

### DIFF
--- a/lib/DAV/handler.js
+++ b/lib/DAV/handler.js
@@ -1339,7 +1339,7 @@ exports.NS_AJAXORG = "http://ajax.org/2005/aml";
                 }
             }
             else {
-                cbprecond(null, false);
+                afterIfNoneMatch();
             }
 
             function afterIfNoneMatch() {
@@ -1357,17 +1357,18 @@ exports.NS_AJAXORG = "http://ajax.org/2005/aml";
                             if (!Util.empty(err))
                                 return cbprecond(err);
                             node = n;
-                            lastMod = node.getLastModified();
-                            if (lastMod) {
-                                lastMod = new Date("@" + lastMod);
-                                if (lastMod <= date) {
-                                    self.httpResponse.writeHead(304);
-                                    self.httpResponse.end();
-                                    cbprecond(null, true);
-                                    // @todo call cbprecond() differently here?
+                            node.getLastModified(function(err, lastMod) {
+                                if (lastMod) {
+                                    lastMod = new Date("@" + lastMod);
+                                    if (lastMod <= date) {
+                                        self.httpResponse.writeHead(304);
+                                        self.httpResponse.end();
+                                        cbprecond(null, true);
+                                        // @todo call cbprecond() differently here?
+                                    }
                                 }
-                            }
-                            afterIfModifiedSince();
+                                afterIfModifiedSince();
+                            });
                         });
                 }
                 else {
@@ -1396,18 +1397,19 @@ exports.NS_AJAXORG = "http://ajax.org/2005/aml";
                     }
 
                     function finale() {
-                        lastMod = node.getLastModified();
-                        if (lastMod) {
-                            lastMod = new Date("@" + lastMod);
-                            if (lastMod > date) {
-                                return cbprecond(Exc.jsDAV_Exception_PreconditionFailed(
-                                    "An If-Unmodified-Since header was specified, but the "
-                                  + "entity has been changed since the specified date.",
-                                    "If-Unmodified-Since")
-                                );
+                        node.getLastModified(function(err, lastMod) {
+                            if (lastMod) {
+                                lastMod = new Date("@" + lastMod);
+                                if (lastMod > date) {
+                                    return cbprecond(new Exc.jsDAV_Exception_PreconditionFailed(
+                                        "An If-Unmodified-Since header was specified, but the "
+                                            + "entity has been changed since the specified date.",
+                                        "If-Unmodified-Since")
+                                                    );
+                                }
                             }
-                        }
-                        cbprecond(null, false);
+                            cbprecond(null, false);
+                        });
                     }
                 }
             }


### PR DESCRIPTION
The code was using node.getLastModified as if it were a
normally returning function (whereas it takes a callback) and
was missing a 'new' before its call to jsDAV_Exception_PreconditionFailed,
which caused it to return null, and thus not take effect.
