### PR TITLE
Fix for GET and HEAD requests

### DIFF
--- a/lib/DAV/handler.js
+++ b/lib/DAV/handler.js
@@ -482,7 +482,7 @@ exports.NS_AJAXORG = "http://ajax.org/2005/aml";
                                 }
                                 return;
                             }
-                            
+
                             // write header on first incoming buffer
                             if (writeStreamingHeader) {
                                 writeStreamingHeader();
@@ -1366,6 +1366,7 @@ exports.NS_AJAXORG = "http://ajax.org/2005/aml";
                                         self.httpResponse.end();
                                         cbprecond(null, true);
                                         // @todo call cbprecond() differently here?
+                                        return;
                                     }
                                 }
                                 afterIfModifiedSince();
@@ -1377,8 +1378,9 @@ exports.NS_AJAXORG = "http://ajax.org/2005/aml";
                 }
 
                 function afterIfModifiedSince() {
+                    var date;
                     if (ifUnmodifiedSince = self.httpRequest.headers["if-unmodified-since"]) {
-                        // The If-Unmodified-Since will allow allow the request if the
+                        // The If-Unmodified-Since will allow the request if the
                         // entity has not changed since the specified date.
                         date = new Date(ifUnmodifiedSince);
                         if (!node) {


### PR DESCRIPTION
The changes are fixing two bugs:
1. No response headers were set in HEAD requests
2. When GET requests made use of `if-modified-since` and the requested file hadn't changed then there were two responses send: Once the (correct) 304 response, once a 200 response submitting the complete file which crashes the server because the former response already closed the connection.
