### PR TITLE
CORS functionality for jsDAV

### DIFF
--- a/lib/DAV/plugins/cors.js
+++ b/lib/DAV/plugins/cors.js
@@ -1,13 +1,15 @@
 /*
  * @package jsDAV
  * @subpackage DAV
- * @copyright Copyright(c) 2011 Ajax.org B.V. <info AT ajax DOT org>
- * @author Mike de Boer <info AT mikedeboer DOT nl>
+ * @copyright Copyright(c) 2013 Mike de Boer. <info AT mikedeboer DOT nl>
+ * @author William J Edney <bedney AT technicalpursuit DOT com>
  * @license http://github.com/mikedeboer/jsDAV/blob/master/LICENSE MIT License
  */
 "use strict";
 
 var jsDAV_ServerPlugin = require("./../plugin");
+
+var jsDAV = require("./../../jsdav");
 
 var Util  = require("./../../shared/util");
 
@@ -18,6 +20,8 @@ var Util  = require("./../../shared/util");
  * standard HTTP headers and any requested 'x-' headers during preflight are
  * allowed, as well as all methods from the core HTTP standard and various
  * WebDAV standards.
+ *
+ * NOTE: This code based heavily on code from John J. Barton.
  */
 var jsDAV_CORS_Plugin = module.exports = jsDAV_ServerPlugin.extend({
     /**
@@ -39,12 +43,12 @@ var jsDAV_CORS_Plugin = module.exports = jsDAV_ServerPlugin.extend({
     },
 
     addCORSHeaders: function(req, resp) {
-
-        Util.log("Receiving headers: " + JSON.stringify(req.headers));
-
         var headers = this.computeCORSHeaders(req);
 
-        Util.log("Returning headers: " + JSON.stringify(headers));
+        if (jsDAV.debugMode) {
+            Util.log("Receiving headers: " + JSON.stringify(req.headers));
+            Util.log("Returning headers: " + JSON.stringify(headers));
+        }
 
         Object.keys(headers).forEach(function(headerName) {
             resp.setHeader(headerName, headers[headerName]);  
@@ -86,7 +90,8 @@ var jsDAV_CORS_Plugin = module.exports = jsDAV_ServerPlugin.extend({
         if (reqHeaders) {
             // Just tell the client what it wants to hear
             return reqHeaders;
-        } else {
+        }
+        else {
             // or tell it everything we know about plus any x- headers it sends
             return Object.keys(req.headers).reduce(
                     function(headers, header) {


### PR DESCRIPTION
This is a slight update to John Barton's CORS plugin made to work under the 0.3.0 plugin architecture. It also contains a few cleanups.
