### PR TITLE
Allow empty lines in htdigest files

### DIFF
--- a/lib/DAV/plugins/auth/file.js
+++ b/lib/DAV/plugins/auth/file.js
@@ -50,7 +50,7 @@ var jsDAV_Auth_Backend_File = module.exports = jsDAV_Auth_Backend_AbstractDigest
             for (; i < l; ++i) {
                 line = lines[i];
                 // empty lines or simply newlines are allowed
-                if (/^[\s\t\n\r]+$/.test(line))
+                if (line === '' || /^[\s\t\n\r]+$/.test(line))
                     continue;
 
                 parts = line.split(":");


### PR DESCRIPTION
In some cases, the line can be an empty string (not a whitespace character), which the given regular expression does not match.

I'd also like some advice on a related issue: any malformed htdigest file leads to a crash without a reasonable error message. The Exc.jsDAV_Exception ends up passed to abstractDigest's requireAuth() method, which attempts to call addHeader() on it. Stack trace:

```
jsDAV/lib/DAV/plugins/auth/abstractDigest.js:226
        err.addHeader("WWW-Authenticate", "Digest realm=\"" + realm + 
            ^
TypeError: Object undefined has no method 'addHeader'
    at Object.module.exports.jsDAV_Auth_iBackend.extend.requireAuth (jsDAV/lib/DAV/plugins/auth/abstractDigest.js:226:13)
    at module.exports.jsDAV_Auth_iBackend.extend.authenticate (jsDAV/lib/DAV/plugins/auth/abstractDigest.js:254:29)
    at next (jsDAV/lib/DAV/plugins/auth/file.js:89:24)
    at module.exports.jsDAV_Auth_Backend_AbstractDigest.extend.loadFile (jsDAV/lib/DAV/plugins/auth/file.js:58:28)
```

Would guarding that addHeader call with a check that err is an instanceof Exc.NotAuthenticated be sufficient? I need to read more of the code to figure out what's supposed to happen here.
