### PR TITLE
Fix validateLock being called more than once

### DIFF
--- a/lib/DAV/plugins/locks.js
+++ b/lib/DAV/plugins/locks.js
@@ -558,6 +558,7 @@ var jsDAV_Locks_Plugin = module.exports = jsDAV_ServerPlugin.extend({
 
         var ret, locks;
         var stopped    = false;
+        var cbCalled   = false;
         var conditions = this.getIfConditions();
         var self       = this;
 
@@ -576,6 +577,7 @@ var jsDAV_Locks_Plugin = module.exports = jsDAV_ServerPlugin.extend({
                     if (!conditions.length && locks.length) {
                         ret = false;
                         cbvalidate(null, ret, locks[0]);
+                        cbCalled = true;
                         stopped = true;
                         return next(Async.STOP);
                     }
@@ -681,6 +683,11 @@ var jsDAV_Locks_Plugin = module.exports = jsDAV_ServerPlugin.extend({
                 });
             })
             .end(function(err) {
+                if (cbCalled) {
+                    // we must not call callback twice
+                    return
+                }
+
                 if (err && !stopped)
                     return cbvalidate(err, false, lastLock);
 


### PR DESCRIPTION
Node crashes if locked file is locked again.

```
Error: Can't render headers after they are sent to the client.
```

How to reproduce:

```
node examples/fileserver.js
curl localhost:8000/1.txt -X LOCK -H "Content-type: text/xml" -d '<?xml version="1.0"?><A:lockinfo xmlns:A="DAV:"><A:locktype><A:write/></A:locktype><A:lockscope><A:shared/></A:lockscope><A:owner><A:href>CURL</A:href></A:owner></A:lockinfo>'
curl localhost:8000/1.txt -X LOCK -H "Content-type: text/xml" -d '<?xml version="1.0"?><A:lockinfo xmlns:A="DAV:"><A:locktype><A:write/></A:locktype><A:lockscope><A:shared/></A:lockscope><A:owner><A:href>CURL</A:href></A:owner></A:lockinfo>'
```
