### PR TITLE
Allow OPTIONS methods to bypass authentication to support CORS.

### DIFF
--- a/lib/DAV/plugins/auth/abstractBasic.js
+++ b/lib/DAV/plugins/auth/abstractBasic.js
@@ -74,6 +74,14 @@ var jsDAV_Auth_Backend_AbstractBasic = module.exports = jsDAV_Auth_iBackend.exte
         var req = handler.httpRequest;
         var res = handler.httpResponse;
 
+        // CORS pre-flight HTTP requests use the OPTIONS method to get the
+        // list of allowed origins, methods, headers, etc. We must allow
+        // the OPTIONS method through without authentication.
+        if (req.method == "OPTIONS") {
+          cbauth(null, true);
+          return;
+        }
+
         var auth = req.headers["authorization"];
         if (!auth || auth.toLowerCase().indexOf("basic") !== 0)
             return this.requireAuth(realm, "No basic authentication headers were found", cbauth);

--- a/lib/DAV/plugins/auth/abstractDigest.js
+++ b/lib/DAV/plugins/auth/abstractDigest.js
@@ -240,6 +240,15 @@ var jsDAV_Auth_Backend_AbstractDigest = module.exports = jsDAV_Auth_iBackend.ext
      */
     authenticate: function(handler, realm, cbauth) {
         var req = handler.httpRequest;
+
+        // CORS pre-flight HTTP requests use the OPTIONS method to get the
+        // list of allowed origins, methods, headers, etc. We must allow
+        // the OPTIONS method through without authentication.
+        if (req.method == "OPTIONS") {
+          cbauth(null, true);
+          return;
+        }
+
         this.init(realm, req);
 
         var username = this.digestParts["username"];


### PR DESCRIPTION
Hey mikedeboer! :D Might surprise you to see me fiddling with this, but in my spare time, I'm hacking on a potential Thunderbird address book rework. Still very vapour-y, but I thought I might use jsDAV as a CardDAV test-server. Ran into this bug (at least, I think it's a bug), and thought you might want the patch.

CORS requires a pre-flight OPTIONS request to be sent to the server
in order for the client to know what methods, origins, headers, etc.
are allowed. This pre-flight request should not request authentication.

See http://stackoverflow.com/questions/15734031/why-does-the-preflight-options-request-of-an-authenticated-cors-request-work-in