### PR TITLE
Add only working plugins to Server.DEFAULT_PLUGINS

### DIFF
--- a/lib/DAV/server.js
+++ b/lib/DAV/server.js
@@ -45,8 +45,12 @@ exports.DEFAULT_PLUGINS = {};
 Fs.readdirSync(__dirname + "/plugins").forEach(function(filename){
     if (/\.js$/.test(filename)) {
         var name = filename.substr(0, filename.lastIndexOf("."));
-        var pluginCls = require("./plugins/" + name);
-        exports.DEFAULT_PLUGINS[pluginCls.name || name] = pluginCls;
+        try {
+            var pluginCls = require("./plugins/" + name);
+            exports.DEFAULT_PLUGINS[pluginCls.name || name] = pluginCls;
+        } catch (e) {
+            Util.log("jsDAV cannot load plugin '" + name + "': " + e.message);
+        }
     }
 });
 


### PR DESCRIPTION
Add a try/catch around the require() call to load the bundled plugins
and use plugins only if there was no exception.
This allows us to have optional dependencies in the plugins.