### PR TITLE
Fix dropbox implementation

### DIFF
--- a/lib/DAV/backends/dropbox/directory.js
+++ b/lib/DAV/backends/dropbox/directory.js
@@ -96,8 +96,8 @@ var jsDAV_Dropbox_Directory = module.exports = jsDAV_Dropbox_Node.extend(jsDAV_C
 
             cbfsgetchildren(null, nodes.map(function(file) {
                 return file.is_dir
-                    ? new jsDAV_Dropbox_Directory(file.path, self.client)
-                    : new jsDAV_Dropbox_File(file.path, self.client);
+                    ? jsDAV_Dropbox_Directory.new(file.path, self.client)
+                    : jsDAV_Dropbox_File.new(file.path, self.client);
             }));
         });
     },


### PR DESCRIPTION
Getting the children node for files breaks. Calling "new jsDAV_Dropbox_file()" causes "object is not a function". Changed to use ".new" instead.