### PR TITLE
fix calendarquery with windows phone

### DIFF
--- a/lib/CalDAV/plugin.js
+++ b/lib/CalDAV/plugin.js
@@ -445,12 +445,16 @@ var jsCalDAV_Plugin = module.exports = jsDAV_Plugin.extend({
 
              // If we're dealing with a calendar, the calendar itself is responsible
              // for the calendar-query.
-             if (depth == 1 && node.hasFeature(jsCalDAV_iCalendar)) {
+             else if (node.hasFeature(jsCalDAV_iCalendar)) {
                 node.calendarQuery(query.filters, function(err, items){
                     if (err)
                         return e.next(err);
                     afterCandidates(items);
                 });
+             }
+
+             else{
+                e.next(Exc.notImplementedYet());
              }
          });
 


### PR DESCRIPTION
Windows Phone does a 
```
http REPORT https://xxxxxx/public/sync/calendars/username/calendarname/ 
'Depth:0' 'Content-type:text/xml'
<?xml version="1.0" encoding="UTF-8"?><calendar-query xmlns="urn:ietf:params:xml:ns:caldav"><prop xmlns="DAV:"><getetag /></prop><filter><comp-filter name="VCALENDAR"><comp-filter name="VEVENT"><time-range start="20150512T000000Z" end="20151110T000000Z" /></comp-filter></comp-filter></filter></calendar-query>
```

, which is not caught by either condition. Moreover, this case is not handled, so request is stuck until it timeouts.

Ping @Olegas for review.