### PR TITLE
Fix signature of jsCardDAV_UserAddressBooks.createFile

### DIFF
--- a/lib/CardDAV/userAddressBooks.js
+++ b/lib/CardDAV/userAddressBooks.js
@@ -92,7 +92,7 @@ var jsCardDAV_UserAddressBooks = module.exports = jsDAV_Collection.extend(jsDAV_
      * @param resource data
      * @return void
      */
-    createFile: function(filename, data, callback) {
+    createFile: function(filename, data, enc, callback) {
         callback(new Exc.MethodNotAllowed("Creating new files in this collection is not supported"));
     },
 


### PR DESCRIPTION
The third parameter of this method should be the character encoding. This lead to an exception being thrown when this method is called