### PR TITLE
implement etags in FS backend

### DIFF
--- a/lib/DAV/backends/fs/file.js
+++ b/lib/DAV/backends/fs/file.js
@@ -158,7 +158,12 @@ var jsDAV_FS_File = module.exports = jsDAV_FS_Node.extend(jsDAV_File, {
      * @return mixed
      */
     getETag: function(cbfsgetetag) {
-        cbfsgetetag(null, null);
+        var stream = Fs.createReadStream(this.path);
+        Util.createHashStream(stream, function(err, hash) {
+            if (err)
+              return cbfsgetetag(err);
+            cbfsgetetag(null, '"' + hash + '"');
+        });
     },
 
     /**


### PR DESCRIPTION
I just copy and pasted from the fsext implementation,
and it seems to work.

I imagine that most implementers will want etags, since
they add considerable safety.

Ref: #111
