### PR TITLE
Remove Locks on DELETE and MOVE

### DIFF
--- a/lib/DAV/plugins/locks.js
+++ b/lib/DAV/plugins/locks.js
@@ -35,6 +35,73 @@ var jsDAV_Locks_Plugin = module.exports = jsDAV_ServerPlugin.extend({
         handler.addEventListener("unknownMethod", this.unknownMethod.bind(this));
         handler.addEventListener("beforeMethod", this.beforeMethod.bind(this));
         handler.addEventListener("afterGetProperties", this.afterGetProperties.bind(this));
+        handler.addEventListener("afterDelete", this.afterDelete.bind(this));
+        handler.addEventListener("afterMove", this.afterMove.bind(this));
+    },
+
+    /**
+     * This method intercepts all MOVE methods to delete all remaining locks on the original resource.
+     * See RFC4918 section 7.7 for more details.
+     *
+     * @param e
+     * @param {String} destinationUri destination URI
+     */
+    afterMove: function(e, destinationUri) {
+        var uri = this.handler.getRequestUri();
+        this.removeLockFromRoot(uri, function(err) {
+            e.next(err);
+        });
+    },
+
+    /**
+     * This method intercepts all DELETE methods to delete all remaining locks rooted on this resource.
+     * See RFC4918 section 9.6 for more details.
+     *
+     * @param e
+     * @param uri {String} deleted object
+     * @return bool
+     */
+    afterDelete: function(e, uri) {
+        this.removeLockFromRoot(uri, function(err) {
+            e.next(err);
+        });
+    },
+
+    /**
+     * Deletes a lock with its root on the given uri from the lock backend (if there is one).
+     *
+     * @param uri URI of the locks root
+     */
+    removeLockFromRoot: function(uri, cbdeletelock) {
+        if (!this.locksBackend)
+            cbdeletelock();
+        // Not sure if returnChildLocks should be true here
+        var self = this;
+        this.getLocks(uri, false, function(err, locks) {
+            if (err) {
+                cbdeletelock(err);
+            } else if(locks) {
+                var callbackCalled = false;
+                Async.list(locks).each(function(lockInfo, next) {
+                    if(lockInfo.uri == uri) {
+                        if (self.locksBackend)
+                            return self.locksBackend.unlock(uri, lockInfo, function(err){
+                                callbackCalled = true;
+                                cbdeletelock(err);
+                            });
+                        next(Async.STOP);
+                    } else {
+                        next();
+                    }
+                }).end(function(err) {
+                    if(!callbackCalled) {
+                        cbdeletelock(err);
+                    }
+                });
+            } else {
+                cbdeletelock();
+            }
+        });
     },
 
     /**


### PR DESCRIPTION
This should fix #151. 
Added a method called removeLockFromRoot to remove a lock from a certain root uri.
Added two event listeners ('afterDelete' and 'afterMove') to call this method.

locks.js on line 80 could be checked. Should the parameter returnChildLocks true or false here?
