### PR TITLE
Fix for enabling spaces in filenames

### DIFF
--- a/lib/DAV/plugins/browser.js
+++ b/lib/DAV/plugins/browser.js
@@ -311,7 +311,7 @@ var jsDAV_Browser_Plugin = module.exports = jsDAV_ServerPlugin.extend({
                         if (Util.rtrim(file["href"], "/") == path)
                             return next();
 
-                        name = encodeURI(Util.splitPath(file["href"])[1] || "");
+                        name = Util.splitPath(file["href"])[1] || "";
 
                         type = null;
 


### PR DESCRIPTION
Filenames were being double encoded, i.e. "foo%2520bar" instead of "foo%20bar".  Solution removes `encodeURI()` on line `314` and leaves line `373` to do the encoding.

Resolves https://github.com/mikedeboer/jsDAV/issues/155