### PR TITLE
改移动文件返回信息为对象，添加srever选项时不启动自带http服务。

### DIFF
--- a/lib/DAV/handler.js
+++ b/lib/DAV/handler.js
@@ -185,7 +185,7 @@ jsDAV_Handler.STATUS_MAP     = {
         // RFC5397
         "{DAV:}current-user-principal"
     ];
-    
+
     /**
      * This property allows you to automatically add the 'resourcetype' value
      * based on a node's classname or interface.
@@ -332,7 +332,7 @@ jsDAV_Handler.STATUS_MAP     = {
             cbgetnodefp(null, node);
         });
     };
-    
+
     /**
      * This method is called with every tree update
      *
@@ -856,7 +856,7 @@ jsDAV_Handler.STATUS_MAP     = {
     this.httpPut = function() {
         var self = this;
         var uri  = this.getRequestUri();
-        
+
         // Intercepting Content-Range
         if (this.httpRequest.headers["content-range"]) {
             /*
@@ -1089,7 +1089,7 @@ jsDAV_Handler.STATUS_MAP     = {
                             self.httpResponse.writeHead(moveInfo.destinationExists ? 204 : 201,
                                 {"content-length": "0"});
                             self.httpResponse.end();
-                            self.dispatchEvent("afterMove", moveInfo.destination);
+                            self.dispatchEvent("afterMove", {source: moveInfo.source,destination: moveInfo.destination});
                         });
                     });
                 });
@@ -1242,7 +1242,7 @@ jsDAV_Handler.STATUS_MAP     = {
         var ctype;
         var self = this;
         var req = this.httpRequest;
-        var isStream = forceStream === true 
+        var isStream = forceStream === true
             ? true
             : (!(ctype = req.headers["content-type"]) || !ctype.match(/(urlencoded|multipart)/i));
 
@@ -1437,7 +1437,7 @@ jsDAV_Handler.STATUS_MAP     = {
                         for (var i = 0, l = ifMatch.length; i < l; ++i) {
                             // Stripping any extra spaces
                             ifMatchItem = Util.trim(ifMatch[i], " ");
-        
+
                             if (etag === ifMatchItem) {
                                 haveMatch = true;
                                 break;
@@ -1762,8 +1762,8 @@ jsDAV_Handler.STATUS_MAP     = {
                         "{DAV:}getcontenttype"
                     ];
                 }
-                
-                
+
+
                 // If the resourceType was not part of the list, we manually add it
                 // and mark it for removal. We need to know the resourcetype in order
                 // to make certain decisions about the entry.
@@ -1822,7 +1822,7 @@ jsDAV_Handler.STATUS_MAP     = {
                             "403" : {},
                             "404" : {}
                         };
-                         
+
                         var myProperties = [].concat(propertyNames);
 
                         var propertyMap = Util.arrayToMap(myProperties);
@@ -2427,7 +2427,7 @@ jsDAV_Handler.STATUS_MAP     = {
                                     });
                                 });
                             }
-                            
+
                             function onDone() {
                                 self.markDirty(parentUri);
                                 self.dispatchEvent("afterBind", uri, Path.join(parent.path, newName));

--- a/lib/DAV/server.js
+++ b/lib/DAV/server.js
@@ -168,6 +168,7 @@ function Server(options) {
                 }
             });
         }
+        return options.server;
     }
     else {
         this.setBaseUri(this.guessBaseUri());


### PR DESCRIPTION
Instead of starting the native HTTP service when adding the srever option, change the file back to the message object.